### PR TITLE
Allow alternative security sources for REST API / Admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ couchbase-server
 * `node['couchbase']['server']['log_dir']`          - The directory Couchbase should log to
 * `node['couchbase']['server']['memory_quota_mb']`  - The per server RAM quota for the entire cluster in megabytes
                                                       defaults to Couchbase's maximum allowed value
+* `node['couchbase']['server']['security_source']`  - The source to obtain the REST API and Admin UI username & password.  Defaults to 'node_attr', also accepts 'citadel'
 * `node['couchbase']['server']['username']`         - The cluster's username for the REST API and Admin UI
 * `node['couchbase']['server']['password']`         - The cluster's password for the REST API and Admin UI
 

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -3,6 +3,7 @@ package_machine = node['kernel']['machine'] == "x86_64" ? "x86_64" : "x86"
 default['couchbase']['server']['edition'] = "community"
 default['couchbase']['server']['version'] = "2.0.1"
 
+default['couchbase']['server']['security_source'] = 'node_attr'
 default['couchbase']['server']['username'] = "Administrator"
 default['couchbase']['server']['password'] = "password"
 
@@ -48,3 +49,4 @@ default['source']['bucket'] = "default"
 default['remote']['bucket'] = "default"
 default['cluster_name'] = "west_cluster"
 default['remote_cluster'] = "remote_cluster"
+

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -49,4 +49,3 @@ default['source']['bucket'] = "default"
 default['remote']['bucket'] = "default"
 default['cluster_name'] = "west_cluster"
 default['remote_cluster'] = "remote_cluster"
-

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      "Installs/Configures Couchbase"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
 version          "1.0.0"
 
-%w{debian ubuntu centos redhat oracle amazon scientific windows}.each do |os|
+%w{debian ubuntu centos redhat oracle amazon scientific windows citadel}.each do |os|
   supports os
 end
 

--- a/recipes/moxi.rb
+++ b/recipes/moxi.rb
@@ -38,7 +38,7 @@ unless (node['recipes'].include?("couchbase::server"))
   when "rhel"
     rpm_package File.join(Chef::Config[:file_cache_path], node['couchbase']['moxi']['package_file'])
   end
-  
+
   service "moxi-server" do
     supports :restart => true, :status => true
     action :enable

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -81,30 +81,40 @@ directory node['couchbase']['server']['database_path'] do
   recursive true
 end
 
+case node['couchbase']['server']['security_source']
+when 'node_attr'
+  username = node['couchbase']['server']['username']
+  password = node['couchbase']['server']['password']
+when 'citadel'
+  sec_conf = JSON.parse(citadel[node['couchbase']['server']['citadel']['key']])
+  username = sec_conf['username']
+  password = sec_conf['password']
+end
+
 couchbase_node "self" do
   database_path node['couchbase']['server']['database_path']
   retry_delay 120
   retries 5
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end
 
 couchbase_cluster "default" do
   memory_quota_mb node['couchbase']['server']['memory_quota_mb']
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end
 
 couchbase_settings "web" do
   settings({
-    "username" => node['couchbase']['server']['username'],
-    "password" => node['couchbase']['server']['password'],
+    "username" => username,
+    "password" => password,
     "port" => 8091,
   })
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -89,6 +89,9 @@ when 'citadel'
   sec_conf = JSON.parse(citadel[node['couchbase']['server']['citadel']['key']])
   username = sec_conf['username']
   password = sec_conf['password']
+else
+  username = node['couchbase']['server']['username']
+  password = node['couchbase']['server']['password']
 end
 
 couchbase_node "self" do

--- a/recipes/setup_cluster.rb
+++ b/recipes/setup_cluster.rb
@@ -9,6 +9,19 @@ prefix = "ns_1@"
 separator=","
 known_nodes=prefix+self.node["ipaddress"]
 
+case node['couchbase']['server']['security_source']
+when 'node_attr'
+  username = node['couchbase']['server']['username']
+  password = node['couchbase']['server']['password']
+when 'citadel'
+  sec_conf = JSON.parse(citadel[node['couchbase']['server']['citadel']['key']])
+  username = sec_conf['username']
+  password = sec_conf['password']
+else
+  username = node['couchbase']['server']['username']
+  password = node['couchbase']['server']['password']
+end
+
 cluster = search(:node, "role:#{cluster_name}")
 cluster.each do |node|
 	if node["ipaddress"] != self.node["ipaddress"]
@@ -16,8 +29,8 @@ cluster.each do |node|
 		known_nodes=known_nodes+separator+prefix+"#{node["ipaddress"]}"
 		add_node "#{cluster_name}" do
   			hostname node["ipaddress"]
-  			username node['couchbase']['server']['username']
-  			password node['couchbase']['server']['password']
+  			username username
+  			password password
 		end
 	end
 end
@@ -25,9 +38,9 @@ end
 ejected_nodes = ""
 cluster_rebal "Rebalance-In Nodes to form a cluster  " do
         ejectedNodes ejected_nodes
-	knownNodes known_nodes
-        username node['couchbase']['server']['username']
-        password node['couchbase']['server']['password']
+	    knownNodes known_nodes
+        username username
+        password password
 end
 
 ruby_block "wait for rebalance completion " do

--- a/recipes/setup_cluster.rb
+++ b/recipes/setup_cluster.rb
@@ -24,23 +24,23 @@ end
 
 cluster = search(:node, "role:#{cluster_name}")
 cluster.each do |node|
-	if node["ipaddress"] != self.node["ipaddress"]
-		log " Adding new nodes"
-		known_nodes=known_nodes+separator+prefix+"#{node["ipaddress"]}"
-		add_node "#{cluster_name}" do
-  			hostname node["ipaddress"]
-  			username username
-  			password password
-		end
-	end
+  if node["ipaddress"] != self.node["ipaddress"]
+    log " Adding new nodes"
+    known_nodes=known_nodes+separator+prefix+"#{node["ipaddress"]}"
+    add_node "#{cluster_name}" do
+      hostname node["ipaddress"]
+      username username
+      password password
+    end
+  end
 end
 
 ejected_nodes = ""
 cluster_rebal "Rebalance-In Nodes to form a cluster  " do
-        ejectedNodes ejected_nodes
-	    knownNodes known_nodes
-        username username
-        password password
+  ejectedNodes ejected_nodes
+  knownNodes known_nodes
+  username username
+  password password
 end
 
 ruby_block "wait for rebalance completion " do
@@ -55,4 +55,3 @@ end
 #  username node['couchbase']['server']['username']
 #  password node['couchbase']['server']['password']
 #end
-

--- a/recipes/setup_xdcr.rb
+++ b/recipes/setup_xdcr.rb
@@ -11,28 +11,37 @@ src_node=src_cluster[0]["ipaddress"]
 remote_cluster = search(:node, "role:#{remote_cluster_name}")
 remote_node=remote_cluster[0]["ipaddress"]
 
-username = node['couchbase']['server']['username']
-password = node['couchbase']['server']['password']
+case node['couchbase']['server']['security_source']
+when 'node_attr'
+  username = node['couchbase']['server']['username']
+  password = node['couchbase']['server']['password']
+when 'citadel'
+  sec_conf = JSON.parse(citadel[node['couchbase']['server']['citadel']['key']])
+  username = sec_conf['username']
+  password = sec_conf['password']
+else
+  username = node['couchbase']['server']['username']
+  password = node['couchbase']['server']['password']
+end
 
 Chef::Log.info "Get uuid information of the remote cluster"
 s_uuid = `curl 'http://#{username}:#{password}@#{remote_node}:8091/pools' | python -mjson.tool |sed -e 's/[","]/''/g' | awk -F "uuid: " '{print $2}'`
 uuid= s_uuid.strip
 
 xdcr_ref "Create XDCR Replication reference  " do
-        uuid uuid
-	remote_name "remote_link"
-	remote_node remote_node
-        username node['couchbase']['server']['username']
-        password node['couchbase']['server']['password']
+  uuid uuid
+  remote_name "remote_link"
+  remote_node remote_node
+  username username
+  password password
 end
 
 xdcr_start "Setting up replication from bucket default to default" do
-        uuid uuid
-        to_cluster "remote_link"
-	from_bucket "default"
-	to_bucket "default"
-        replication_type "continuous"
-        username node['couchbase']['server']['username']
-        password node['couchbase']['server']['password']
+  uuid uuid
+  to_cluster "remote_link"
+  from_bucket "default"
+  to_bucket "default"
+  replication_type "continuous"
+  username username
+  password password
 end
-

--- a/recipes/test_buckets.rb
+++ b/recipes/test_buckets.rb
@@ -24,19 +24,32 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
+case node['couchbase']['server']['security_source']
+when 'node_attr'
+  username = node['couchbase']['server']['username']
+  password = node['couchbase']['server']['password']
+when 'citadel'
+  sec_conf = JSON.parse(citadel[node['couchbase']['server']['citadel']['key']])
+  username = sec_conf['username']
+  password = sec_conf['password']
+else
+  username = node['couchbase']['server']['username']
+  password = node['couchbase']['server']['password']
+end
+
 couchbase_bucket "default" do
   memory_quota_mb 100
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end
 
 couchbase_bucket "memcached" do
   memory_quota_mb 100
   type "memcached"
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end
 
 couchbase_bucket "modified mb creation" do
@@ -45,8 +58,8 @@ couchbase_bucket "modified mb creation" do
   memory_quota_mb 100
   replicas false
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end
 
 couchbase_bucket "modified % creation" do
@@ -54,8 +67,8 @@ couchbase_bucket "modified % creation" do
   type "couchbase"
   memory_quota_percent 0.1
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end
 
 ruby_block "wait for bucket creation, which is asynchronous" do
@@ -70,8 +83,8 @@ couchbase_bucket "modified mb modification" do
   memory_quota_mb 125
   replicas 2
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end
 
 couchbase_bucket "modified % modification" do
@@ -79,6 +92,6 @@ couchbase_bucket "modified % modification" do
   type "couchbase"
   memory_quota_percent 0.125
 
-  username node['couchbase']['server']['username']
-  password node['couchbase']['server']['password']
+  username username
+  password password
 end


### PR DESCRIPTION
Node attributes are not secure -- they can be read by every node.  Data bags are not a good way to store/ship secure credentials either.  I use Citadel which allows nodes with correct AWS IAM privileges to get files from S3 buckets, where I keep the data in whatever format I like (in this case JSON).